### PR TITLE
Backwell 12.8 support

### DIFF
--- a/cmake/external_projects/flashmla.cmake
+++ b/cmake/external_projects/flashmla.cmake
@@ -19,7 +19,7 @@ else()
   FetchContent_Declare(
         flashmla
         GIT_REPOSITORY https://github.com/vllm-project/FlashMLA
-        GIT_TAG 9140b54f8ca80a32b69972b46a68bfd0de4501b8
+        GIT_TAG e350c2d2e42f069ced7ceee68804f224553899ac
         GIT_PROGRESS TRUE
         CONFIGURE_COMMAND ""
         BUILD_COMMAND ""
@@ -38,7 +38,7 @@ set(SUPPORT_ARCHS)
 if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER 12.3)
     list(APPEND SUPPORT_ARCHS 9.0a)
 endif()
-if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER 12.9)
+if(${CMAKE_CUDA_COMPILER_VERSION} VERSION_GREATER 12.8)
     list(APPEND SUPPORT_ARCHS 10.0a)
 endif()
 


### PR DESCRIPTION
Support building FlashMLA on Blackwell with 12.8 via:
https://github.com/vllm-project/FlashMLA/commit/e350c2d2e42f069ced7ceee68804f224553899ac

```
vllm serve deepseek-ai/DeepSeek-V3.2-Exp -tp 8

lm_eval --model local-completions --model_args "base_url=http://0.0.0.0:8000/v1/completions,model=deepseek-ai/DeepSeek-V3.2-Exp,num_concurrent=256" --tasks gsm8k --limit 256
...
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9766|±  |0.0095|
|     |       |strict-match    |     5|exact_match|↑  |0.9766|±  |0.0095|
```